### PR TITLE
/ldp/config entry-points work with non-string values

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -4,7 +4,7 @@ $(TARGET): main.go config-file.go getdbinfo.go http-error.go server.go ldp-confi
 	go build -o $@
 
 run: $(TARGET)
-	cd ..; env LOGCAT=op,curl,status,response,db OKAPI_URL=https://folio-snapshot-okapi.dev.folio.org OKAPI_TENANT=diku OKAPI_USER=diku_admin src/$(TARGET) etc/config.json
+	cd ..; env LOGCAT=listen,op,curl,status,response,db OKAPI_URL=https://folio-snapshot-okapi.dev.folio.org OKAPI_TENANT=diku OKAPI_USER=diku_admin src/$(TARGET) etc/config.json
 
 lint:
 	-go vet ./...

--- a/src/ldp-config.go
+++ b/src/ldp-config.go
@@ -160,7 +160,7 @@ func underlyingHandleConfigKey(w http.ResponseWriter, req *http.Request, server 
 
 	w.Header().Set("Content-Type", "application/json")
 	_, err = w.Write(bytes)
-	return nil
+	return err
 }
 
 
@@ -199,18 +199,13 @@ func writeConfigKey(w http.ResponseWriter, req *http.Request, server *ModReporti
 		method = "PUT"
 		path = "settings/entries/" + id
 	} else {
-		dumbId, err := uuid.NewRandom()
-		if err != nil {
-			return fmt.Errorf("could not generate v4 UUID: %s", err)
+		dumbId, err2 := uuid.NewRandom()
+		if err2 != nil {
+			return fmt.Errorf("could not generate v4 UUID: %s", err2)
 		}
 		id = dumbId.String()
 		method = "POST"
 		path = "settings/entries"
-	}
-
-	bytes, err = json.Marshal(item.Value)
-	if err != nil {
-		return fmt.Errorf("could not serialize JSON for value: %s", err)
 	}
 
 	var simpleSettingsItem map[string]interface{} = map[string]interface{}{
@@ -220,7 +215,7 @@ func writeConfigKey(w http.ResponseWriter, req *http.Request, server *ModReporti
 		"value": item.Value,
 	}
 	fmt.Printf("simpleSettingsItem = %+v\n", simpleSettingsItem)
-	bytes, err = server.folioSession.Fetch(path, foliogo.RequestParams{
+	_, err = server.folioSession.Fetch(path, foliogo.RequestParams{
 		Method: method,
 		Json: simpleSettingsItem,
 	})

--- a/src/ldp-config.go
+++ b/src/ldp-config.go
@@ -40,8 +40,21 @@ type configItem struct {
 }
 
 
+type handlerFn func(w http.ResponseWriter, req *http.Request, server *ModReportingServer) error;
+
+
 func handleConfig(w http.ResponseWriter, req *http.Request, server *ModReportingServer) {
-	err := underlyingHandleConfig(w, req, server)
+	runWithErrorHandling(w, req, server, underlyingHandleConfig)
+}
+
+
+func handleConfigKey(w http.ResponseWriter, req *http.Request, server *ModReportingServer) {
+	runWithErrorHandling(w, req, server, underlyingHandleConfigKey)
+}
+
+
+func runWithErrorHandling(w http.ResponseWriter, req *http.Request, server *ModReportingServer, f handlerFn) {
+	err := f(w, req, server)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprintln(w, err.Error())
@@ -96,15 +109,6 @@ func underlyingHandleConfig(w http.ResponseWriter, req *http.Request, server *Mo
 	w.Header().Set("Content-Type", "application/json")
 	_, _ = w.Write(bytes)
 	return nil
-}
-
-
-func handleConfigKey(w http.ResponseWriter, req *http.Request, server *ModReportingServer) {
-	err := underlyingHandleConfigKey(w, req, server)
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		fmt.Fprintln(w, err.Error())
-	}
 }
 
 

--- a/src/ldp-config.go
+++ b/src/ldp-config.go
@@ -66,9 +66,21 @@ func handleConfig(w http.ResponseWriter, req *http.Request, server *ModReporting
 	tenant := server.folioSession.GetTenant()
 	config := make([]configItem, len(r.Items))
 	for i, item := range(r.Items) {
+		fmt.Printf("converting item %v\n", item)
+		value, ok := item.Value.(string)
+		if !ok {
+			// mod-settings can contain values of any type: needs serializing
+			bytes, err = json.Marshal(item.Value)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				fmt.Fprintf(w, "could not serialize value from mod-settings: %s", err)
+				return
+			}
+			value = string(bytes)
+		}
 		config[i] = configItem{
 			Key: item.Key,
-			Value: item.Value.(string),
+			Value: value,
 			Tenant: tenant,
 		}
 	}


### PR DESCRIPTION
Sometimes the value stored in a mod-settings entry is a string, in which case we can (and do) return it as-is. But sometimes it is not — for example, it might be a JSON object. In these cases, we serialise to a string a return that as the value of the `/ldp/config` entry.

As part of fixing this I refactored the handlers for `/ldp/config` and `/ldp/config/{key}` so both return errors (or `nil`) and both use a new shared function `settingsItemToConfigItem` to handle the non-string case.