### PR TITLE
[MODREP-49] Support ReShare derived tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for mod-reporting
 
+## [1.6.0](https://github.com/folio-org/mod-reporting/tree/v1.6.0) (IN PROGRESS)
+
+* Extend `/ldp/db/tables` SQL query so that the response includes tables in the `reshare_derived` schema. Fixes MODREP-49.
+
 ## [1.5.0](https://github.com/folio-org/mod-reporting/tree/v1.5.0) (2025-11-25)
 
 * Postgres query timeout is configurable both as `queryTimeout` in the config file and (overriding this) in the `MOD_REPORTING_QUERY_TIMEOUT` environment variable. Defaults to 60 seconds if neither is specified. Also, fixes a bug where reports running for more than 30 seconds would result in the connection to the client being silently dropped. Fixes MODREP-42.

--- a/src/reporting.go
+++ b/src/reporting.go
@@ -58,11 +58,11 @@ func fetchTables(dbConn PgxIface, isMetaDB bool) ([]dbTable, error) {
 	if isMetaDB {
 		query = `SELECT schema_name, table_name FROM metadb.base_table
 			 UNION
-			 SELECT 'folio_derived', table_name
+			 SELECT schema_name, table_name
 			     FROM metadb.table_update t
 			         JOIN pg_class c ON c.relname=t.table_name
 			         JOIN pg_namespace n ON n.oid=c.relnamespace AND n.nspname=t.schema_name
-			     WHERE schema_name='folio_derived'`
+			     WHERE schema_name='folio_derived' OR schema_name='reshare_derived'`
 	} else {
 		query = "SELECT table_name, table_schema as schema_name FROM information_schema.tables WHERE table_schema IN ('local', 'public', 'folio_reporting')"
 	}


### PR DESCRIPTION
Extend `/ldp/db/tables` SQL query so that the response includes tables in the `reshare_derived` schema as well as `folio_derived`.